### PR TITLE
App configuration re-organisation

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,27 @@
 {
-  "extends": "airbnb"
+  "extends": [
+    "airbnb",
+    "prettier"
+  ],
+  "rules": {
+    "consistent-return": 0,
+    "no-shadow": 0,
+    "no-prototype-builtins": 0,
+    "valid-jsdoc": [
+      "error",
+      {
+        "prefer": {
+          "arg": "param",
+          "argument": "param",
+          "return": "returns"
+        },
+        "preferType": {
+          "boolean": "Boolean",
+          "number": "Number",
+          "object": "Object",
+          "string": "String"
+        }
+      }
+    ]
+  }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,6 +7,7 @@
     "consistent-return": 0,
     "no-shadow": 0,
     "no-prototype-builtins": 0,
+    "camelcase": 0,
     "valid-jsdoc": [
       "error",
       {

--- a/config/config.defaults.js
+++ b/config/config.defaults.js
@@ -1,0 +1,31 @@
+/*
+ * Configuration defaults
+ *
+ * Can also hold non-secret, environment-invariant configuration
+ * Merged into environment-specific configurations
+ */
+module.exports = {
+  env: 'dev',
+  web: {
+    host: 'localhost',
+    port: 1000,
+    tls: null,
+  },
+  psql: {
+    host: null,
+    port: null,
+    database: null,
+    user: null,
+    password: null,
+    ssl: false,
+  },
+  email: {
+    postmark_key: null,
+    twine_email: process.env.CB_EMAIL,
+  },
+  session: {
+    jwt_secret: process.env.JWT_SECRET,
+    hmac_secret: process.env.HMAC_SECRET,
+    ttl: 30 * 60 * 1000, // 30 minutes in ms
+  },
+};

--- a/config/config.schema.js
+++ b/config/config.schema.js
@@ -1,0 +1,38 @@
+/*
+ * Configuration object schema
+ *
+ * Specifies the required shape and content of the configuration object.
+ */
+const Joi = require('joi');
+
+module.exports = {
+  env: Joi.string().only('dev', 'test', 'prod'),
+  web: Joi.object({
+    host: Joi.string().min(1),
+    port: Joi.number().min(0).max(65535).required(),
+    tls: Joi.alternatives().try(
+      Joi.only(null),
+      Joi.object({
+        key: Joi.string().required(),
+        cert: Joi.string().required(),
+      }),
+    ),
+  }),
+  psql: Joi.object({
+    host: Joi.string().min(1).required(),
+    port: Joi.number().min(0).max(65535).required(),
+    database: Joi.string().min(1).required(),
+    user: Joi.string().min(1).required(),
+    password: Joi.string(),
+    ssl: Joi.bool().default(false),
+  }),
+  email: Joi.object({
+    postmark_key: Joi.string().required(),
+    twine_email: Joi.string().email().required(),
+  }),
+  session: Joi.object({
+    jwt_secret: Joi.string().min(20).required(),
+    hmac_secret: Joi.string().min(20).required(),
+    ttl: Joi.number().integer().min(0).max(3e10), // milliseconds
+  }),
+};

--- a/config/index.js
+++ b/config/index.js
@@ -60,7 +60,7 @@ const nodeEnvs = {
     mergeDeepRight(cfg, {
       env: 'prod',
       web: { port: 3002 },
-      psql: parseDbUrl(process.env.DATABASE_URL_PROD),
+      psql: parseDbUrl(process.env.DATABASE_URL || process.env.DATABASE_URL_PROD),
       email: { postmark_key: process.env.POSTMARK_KEY_PROD },
     }),
 };

--- a/config/index.js
+++ b/config/index.js
@@ -101,8 +101,17 @@ const validateConfig = (cfg) => {
   return value;
 };
 
+/**
+ * Utility shortcut for reading and validating configuration
+ * @param   {String} env    Deployment environment
+ * @param   {String} [path] Optional path for configuration override file
+ * @returns {Object}        Validated configuration object
+ */
+const getConfig = (env, path) => validateConfig(readConfig(env, path));
+
 
 module.exports = {
   readConfig,
   validateConfig,
+  getConfig,
 };

--- a/config/index.js
+++ b/config/index.js
@@ -1,0 +1,108 @@
+/*
+ * Configuration entry point
+ *
+ * Exports functions used to generate a single normalised configuration object
+ */
+require('env2')('./config/config.env');
+
+const fs = require('fs');
+const url = require('url');
+const Joi = require('joi');
+const { mergeDeepRight } = require('ramda');
+const schema = require('./config.schema');
+const defaults = require('./config.defaults');
+
+
+/**
+ * Parses database connection string into connection object
+ * used by node-postgres Client constructor
+ *
+ * @param   {String} str Database URL to parse
+ * @returns {Object}     Database connection parameters
+ */
+const parseDbUrl = (str) => {
+  const {
+    auth,
+    pathname: database,
+    hostname: host,
+    port,
+    query: { ssl },
+  } = url.parse(str, true);
+
+  const [user, password] = auth.split(':')
+
+  return { database, host, port, user, password, ssl: Boolean(ssl) };
+}
+
+
+/**
+ * Describes the transformations of the default configuration object
+ * in the various supported deployment environments
+ */
+const nodeEnvs = {
+  dev: (cfg) =>
+    mergeDeepRight(cfg, {
+      env: 'dev',
+      web: { port: 3000 },
+      psql: parseDbUrl(process.env.DATABASE_URL_DEV),
+      email: { postmark_key: process.env.POSTMARK_KEY_DEV },
+    }),
+
+  test: (cfg) =>
+    mergeDeepRight(cfg, {
+      env: 'test',
+      web: { port: 3001 },
+      psql: parseDbUrl(process.env.DATABASE_URL_TEST),
+      email: { postmark_key: process.env.POSTMARK_KEY_TEST },
+    }),
+
+  prod: (cfg) =>
+    mergeDeepRight(cfg, {
+      env: 'prod',
+      web: { port: 3002 },
+      psql: parseDbUrl(process.env.DATABASE_URL_PROD),
+      email: { postmark_key: process.env.POSTMARK_KEY_PROD },
+    }),
+};
+
+
+/**
+ * Given the deployment environment, applies the appropriate
+ * transformations to the default config.
+ *
+ * Allows an optional filepath for a config override JSON file.
+ *
+ * @param   {String} [env=dev] Environment for which to get config
+ * @param   {String} [path]    Path from which to read optional config file
+ * @returns {Object}           Fully merged configuration object
+ */
+const readConfig = (env = 'dev', path) => {
+  const config = path
+    ? JSON.parse(fs.readFileSync(path, 'utf8'))
+    : {};
+
+  return mergeDeepRight(nodeEnvs[env](defaults), config);
+};
+
+
+/**
+ * Validates the given configuration object against the default schema
+ *
+ * @param   {Object} cfg Configuration object to validate
+ * @returns {Object}     Parsed and validated configuration object
+ */
+const validateConfig = (cfg) => {
+  const { error, value } = Joi.validate(cfg, schema);
+
+  if (error) {
+    throw error;
+  }
+
+  return value;
+};
+
+
+module.exports = {
+  readConfig,
+  validateConfig,
+};

--- a/docs/config_guide.md
+++ b/docs/config_guide.md
@@ -1,24 +1,31 @@
 # Configuration Guide
-Currently all configuration is done via a single git-ignored configuration file in the project root.
+All configuration is stored in the `config` directory located in the project root.
 
-To create a project configuration, create a file named `config.env` in the project root. Populate it with `=`-separated key-value pairs. Ensure at least the following parameters are provided:
+Secrets and configuration variables that are likely to change between deployment environments are stored in a file called `config.env`. This file should *NOT* be checked into source control.
+
+Default configuration variables are stored in `config.defaults.js`.
+
+To create a project configuration, create the `config.env` in the `config` directory. Populate it with `=`-separated key-value pairs. Ensure at least the following parameters are provided:
 
 ```sh
-# Used to sign JWT for community business (CB) users
-SECRET=...
+# Used as a HMAC key to hash passwords (must change, see https://github.com/TwinePlatform/DataPower/issues/213)
+HMAC_SECRET=...
 
-# Used to sign JWT for admin users
-ADMIN SECRET=...
+# Used to sign JWTs for session authentication
+JWT SECRET=...
 
-# what?
-POSTMARK_SERVER=...
+# Postgres connection strings for postgres server in various environments
+# DATABASE_URL is used in production, the others are suffixed with their environments
+DATABASE_URL=...
+DATABASE_URL_DEV=...
+DATABASE_URL_TEST=...
 
-# what?
-CB_EMAIL=foo@bar.com
+# Postmark API key for various environments
+# Postmark is the service used to send e-mails
+POSTMARK_KEY_DEV=...
+POSTMARK_KEY_TEST=...
+POSTMARK_KEY_PROD=...
 
-# Full postgres URL to the development postgres server
-DATABASE_URL=postgres://<username>:<password>@<host>:<port>/<database_name>?ssl=1
-
-# Full postgres URL to the testing postgres sever
-DATABASE_TEST=postgres://<username>:<password>@<host>:<port>/<database_name>?ssl=0
+# Used in development only. MUST BE REPLACED before launch
+CB_EMAIL=...
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -3850,6 +3850,21 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
+    "isemail": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.1.1.tgz",
+      "integrity": "sha512-mVjAjvdPkpwXW61agT2E9AkGoegZO7SdJGCezWwxnETL58f5KwJ4vSVAMBUL5idL6rTlYAIGkX3n4suiviMLNw==",
+      "requires": {
+        "punycode": "2.1.0"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
+          "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0="
+        }
+      }
+    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -3892,6 +3907,23 @@
         "uglify-js": "2.8.29",
         "void-elements": "2.0.1",
         "with": "4.0.3"
+      }
+    },
+    "joi": {
+      "version": "13.1.2",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-13.1.2.tgz",
+      "integrity": "sha512-bZZSQYW5lPXenOfENvgCBPb9+H6E6MeNWcMtikI04fKphj5tvFL9TOb+H2apJzbCrRw/jebjTH8z6IHLpBytGg==",
+      "requires": {
+        "hoek": "5.0.3",
+        "isemail": "3.1.1",
+        "topo": "3.0.0"
+      },
+      "dependencies": {
+        "hoek": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-5.0.3.tgz",
+          "integrity": "sha512-Bmr56pxML1c9kU+NS51SMFkiVQAb+9uFfXwyqR2tn4w2FPvmPt65eZ9aCcEfRXd9G74HkZnILC6p967pED4aiw=="
+        }
       }
     },
     "js-string-escape": {
@@ -6972,6 +7004,11 @@
         }
       }
     },
+    "ramda": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.25.0.tgz",
+      "integrity": "sha512-GXpfrYVPwx3K7RQ6aYT8KPS8XViSXUVJT1ONhoKPE9VAleW42YE+U+8VEyGWt41EnEQW7gwecYJriTI0pKoecQ=="
+    },
     "range-parser": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
@@ -8304,6 +8341,21 @@
       "requires": {
         "is-number": "3.0.0",
         "repeat-string": "1.6.1"
+      }
+    },
+    "topo": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/topo/-/topo-3.0.0.tgz",
+      "integrity": "sha512-Tlu1fGlR90iCdIPURqPiufqAlCZYzLjHYVVbcFWDMcX7+tK8hdZWAfsMrD/pBul9jqHHwFjNdf1WaxA9vTRRhw==",
+      "requires": {
+        "hoek": "5.0.3"
+      },
+      "dependencies": {
+        "hoek": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-5.0.3.tgz",
+          "integrity": "sha512-Bmr56pxML1c9kU+NS51SMFkiVQAb+9uFfXwyqR2tn4w2FPvmPt65eZ9aCcEfRXd9G74HkZnILC6p967pED4aiw=="
+        }
       }
     },
     "touch": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "main": "index.js",
   "scripts": {
-    "start": "node ./react-backend/app.js",
+    "start": "node ./react-backend/index.js",
     "devstart": "nodemon ./react-backend/bin/www",
     "postinstall": "cd react-backend/client && npm install",
     "heroku-postbuild": "cd react-backend/client && npm install --only=dev && npm install && npm run build",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "env2": "^2.2.0",
     "express": "~4.15.2",
     "jade": "~1.11.0",
+    "joi": "^13.1.2",
     "jsonwebtoken": "^8.1.1",
     "morgan": "~1.8.1",
     "node-base64-image": "^1.0.4",
@@ -70,6 +71,7 @@
     "postmark": "^1.5.0",
     "qrcode": "^0.9.0",
     "querystring": "^0.2.0",
+    "ramda": "^0.25.0",
     "serve-favicon": "~2.4.2",
     "url": "^0.11.0",
     "validator": "^9.4.1"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "heroku-postbuild": "cd react-backend/client && npm install --only=dev && npm install && npm run build",
     "build.client": "cd react-backend/client && npm run build",
     "db_build": "node ./react-backend/database/dbBuild",
-    "test": "NODE_ENV=test tape tests/**/*.test.js | tap-spec",
+    "test": "NODE_ENV=test tape 'tests/**/*.test.js' | tap-spec",
     "cover": "nyc npm test",
     "cover.report": "nyc report --reporter=html",
     "cover.report.ci": "nyc report --reporter=text-lcov > coverage.lcov",

--- a/react-backend/.eslintrc.json
+++ b/react-backend/.eslintrc.json
@@ -1,8 +1,0 @@
-{
-  "extends": ["airbnb", "prettier"],
-  "rules": {
-    "consistent-return": 0,
-    "no-shadow": 0,
-    "camelcase": 0
-  }
-}

--- a/react-backend/database/dbConnection.js
+++ b/react-backend/database/dbConnection.js
@@ -1,10 +1,10 @@
 const { Pool } = require('pg');
-require('env2')('./config.env');
+require('env2')('./config/config.env');
 
 /* istanbul ignore next */
 const DB_URL =
   process.env.NODE_ENV === 'test'
-    ? process.env.DATABASE_TEST
+    ? process.env.DATABASE_URL_TEST
     : process.env.DATABASE_URL;
 
 /* istanbul ignore next */

--- a/react-backend/database/dbConnectionLazy.js
+++ b/react-backend/database/dbConnectionLazy.js
@@ -1,0 +1,3 @@
+const pg = require('pg');
+
+module.exports = (cfg) => new pg.Pool(cfg.psql);

--- a/react-backend/functions/cbhash.js
+++ b/react-backend/functions/cbhash.js
@@ -1,12 +1,4 @@
-const crypto = require('crypto');
-require('env2')('./config.env');
-
-if (!process.env.SECRET) {
-  throw new Error('Environment variable SECRET must be set');
-}
-const secret = process.env.SECRET;
-
-module.exports = pswd => {
+module.exports = (secret, pswd) => {
   const hash = crypto
     .createHmac('sha256', secret)
     .update(pswd)

--- a/react-backend/functions/cbhash.js
+++ b/react-backend/functions/cbhash.js
@@ -1,3 +1,5 @@
+const crypto = require('crypto');
+
 module.exports = (secret, pswd) => {
   const hash = crypto
     .createHmac('sha256', secret)

--- a/react-backend/functions/hash.js
+++ b/react-backend/functions/hash.js
@@ -1,3 +1,5 @@
+const crypto = require('crypto');
+
 module.exports = (secret, userObject) => {
   let userString =
     userObject.formSender + userObject.formEmail + userObject.formSex + userObject.formYear;

--- a/react-backend/functions/hash.js
+++ b/react-backend/functions/hash.js
@@ -1,10 +1,4 @@
-const crypto = require('crypto');
-require('env2')('./config.env');
-
-if (!process.env.SECRET) throw new Error('Environment variable SECRET must be set');
-const secret = process.env.SECRET;
-
-module.exports = (userObject) => {
+module.exports = (secret, userObject) => {
   let userString =
     userObject.formSender + userObject.formEmail + userObject.formSex + userObject.formYear;
   userString = userString.replace(/\s/g, '');

--- a/react-backend/functions/qr_send.js
+++ b/react-backend/functions/qr_send.js
@@ -2,12 +2,12 @@ const qrCodeMaker = require('../functions/qrcodemaker');
 const generatePdf = require('../functions/pdfgenerator');
 const sendemail = require('../functions/sendemail');
 
-const sendQrCode = (email, name, hash, cbLogo) => {
+const sendQrCode = (client, email, name, hash, cbLogo) => {
   if (!email) return console.log('Missing the person to deliver this email to');
 
   qrCodeMaker(hash)
     .then(QRcodeBase64Url => generatePdf(QRcodeBase64Url, cbLogo))
-    .then(pdf => sendemail(email, name, pdf))
+    .then(pdf => sendemail(client, email, name, pdf))
     .catch(err => {
       console.log('Failed to send email ', err);
     });

--- a/react-backend/functions/sendCBemail.js
+++ b/react-backend/functions/sendCBemail.js
@@ -1,13 +1,4 @@
-const postmark = require('postmark');
-require('env2')('./config.env');
-
-if (!process.env.POSTMARK_SERVER) {
-  throw new Error('Environment variable POSTMARK_SERVER must be set');
-}
-
-const client = new postmark.Client(process.env.POSTMARK_SERVER);
-
-module.exports = (email, name) => {
+module.exports = (client, email, name) => {
   const messages = [
     {
       From: 'visitorapp@powertochange.org.uk',

--- a/react-backend/functions/sendResetEmail.js
+++ b/react-backend/functions/sendResetEmail.js
@@ -1,13 +1,4 @@
-const postmark = require('postmark');
-require('env2')('./config.env');
-
-if (!process.env.POSTMARK_SERVER) {
-  throw new Error('Environment variable POSTMARK_SERVER must be set');
-}
-
-const client = new postmark.Client(process.env.POSTMARK_SERVER);
-
-module.exports = (email, token) => {
+module.exports = (client, email, token) => {
   client.sendEmailWithTemplate({
     From: 'visitorapp@powertochange.org.uk',
     TemplateId: 4148361,

--- a/react-backend/functions/sendemail.js
+++ b/react-backend/functions/sendemail.js
@@ -1,13 +1,4 @@
-const postmark = require('postmark');
-require('env2')('./config.env');
-
-if (!process.env.POSTMARK_SERVER) {
-  throw new Error('Environment variable POSTMARK_SERVER must be set');
-}
-
-const client = new postmark.Client(process.env.POSTMARK_SERVER);
-
-module.exports = (email, name, pdf) => {
+module.exports = (client, email, name, pdf) => {
   const messages = [
     {
       From: 'visitorapp@powertochange.org.uk',

--- a/react-backend/index.js
+++ b/react-backend/index.js
@@ -1,0 +1,18 @@
+/*
+ * Entry point for the application
+ */
+const util = require('util');
+const { readConfig, validateConfig } = require('../config');
+const createApp = require('./app');
+
+const env = process.env.NODE_ENV;
+const arg = process.argv[2];
+
+const config = validateConfig(readConfig(env, arg));
+
+console.log(`Attempting to start app in "${env}" environment`);
+console.log('Using the following configuration');
+console.log(util.inspect(config, { depth: 3 }));
+
+createApp(config)
+  .listen(config.web.port, () => console.log(`Server listening on ${config.web.port}`));

--- a/react-backend/routes/admin_login.js
+++ b/react-backend/routes/admin_login.js
@@ -7,7 +7,8 @@ const router = express.Router();
 
 router.post('/', (req, res, next) => {
   const { password } = req.body;
-  const hashedPassword = hashCB(password);
+  const secret = req.app.get('cfg').session.hmac_secret;
+  const hashedPassword = hashCB(secret, password);
 
   cbLogin(req.auth.cb_email, hashedPassword)
     .then(exists => {

--- a/react-backend/routes/admin_login.js
+++ b/react-backend/routes/admin_login.js
@@ -8,6 +8,7 @@ const router = express.Router();
 router.post('/', (req, res, next) => {
   const { password } = req.body;
   const secret = req.app.get('cfg').session.hmac_secret;
+  const jwtSecret = req.app.get('cfg').session.jwt_secret;
   const hashedPassword = hashCB(secret, password);
 
   cbLogin(req.auth.cb_email, hashedPassword)
@@ -15,7 +16,7 @@ router.post('/', (req, res, next) => {
       if (exists) {
         const token = jwt.sign(
           { email: req.auth.cb_email, admin: true },
-          process.env.ADMIN_SECRET,
+          jwtSecret,
           { expiresIn: '5m' }
         );
 

--- a/react-backend/routes/cbauthentication/cb_login.js
+++ b/react-backend/routes/cbauthentication/cb_login.js
@@ -8,7 +8,7 @@ const { checkHasLength } = require('../../functions/helpers');
 router.post('/', (req, res, next) => {
   const { formEmail, formPswd } = req.body;
   const secret = req.app.get('cfg').session.hmac_secret;
-
+  const jwtSecret = req.app.get('cfg').session.jwt_secret;
   const notEmail = (!validator.isEmail(formEmail) && 'email') || '';
   const noInput = (!checkHasLength([formEmail, formPswd]) && 'noinput') || '';
 
@@ -21,7 +21,7 @@ router.post('/', (req, res, next) => {
   cbLogin(formEmail, passwordHash)
     .then(exists => {
       if (exists) {
-        const token = jwt.sign({ email: formEmail }, process.env.SECRET);
+        const token = jwt.sign({ email: formEmail }, jwtSecret);
         const loggedInResponse = { success: true, token };
         res.send(loggedInResponse);
       } else {

--- a/react-backend/routes/cbauthentication/cb_login.js
+++ b/react-backend/routes/cbauthentication/cb_login.js
@@ -7,6 +7,7 @@ const { checkHasLength } = require('../../functions/helpers');
 
 router.post('/', (req, res, next) => {
   const { formEmail, formPswd } = req.body;
+  const secret = req.app.get('cfg').session.hmac_secret;
 
   const notEmail = (!validator.isEmail(formEmail) && 'email') || '';
   const noInput = (!checkHasLength([formEmail, formPswd]) && 'noinput') || '';
@@ -15,7 +16,7 @@ router.post('/', (req, res, next) => {
 
   if (validationError) return res.status(400).send({ reason: validationError });
 
-  const passwordHash = hashCB(formPswd);
+  const passwordHash = hashCB(secret, formPswd);
 
   cbLogin(formEmail, passwordHash)
     .then(exists => {

--- a/react-backend/routes/cbauthentication/cb_password_change.js
+++ b/react-backend/routes/cbauthentication/cb_password_change.js
@@ -11,6 +11,7 @@ const strongPassword = new RegExp(
 
 router.post('/', (req, res, next) => {
   const { formPswd, formPswdConfirm, token } = req.body;
+  const secret = req.app.get('cfg').session.hmac_secret;
 
   Promise.all([checkExists(token), checkExpire(token)])
     .then(([exists, notExpired]) => {
@@ -28,7 +29,7 @@ router.post('/', (req, res, next) => {
 
       if (validationError) return res.status(400).send(validationError);
 
-      const password = hash(formPswd);
+      const password = hash(secret, formPswd);
       pwdChange(password, token)
         .then(() => {
           res.send(true);

--- a/react-backend/routes/cbauthentication/cb_password_reset.js
+++ b/react-backend/routes/cbauthentication/cb_password_reset.js
@@ -6,6 +6,7 @@ const pwdTokenAdd = require('../../database/queries/cb/pwd_token_add');
 const sendResetEmail = require('../../functions/sendResetEmail');
 
 router.post('/', (req, res, next) => {
+  const pmClient = req.app.get('client:postmark');
   const { formEmail } = req.body;
   const tokenExpire = Date.now() + 3600000;
 
@@ -24,7 +25,7 @@ router.post('/', (req, res, next) => {
           .then(token =>
             Promise.all([
               pwdTokenAdd(token, tokenExpire, formEmail),
-              sendResetEmail(formEmail, token)
+              sendResetEmail(pmClient, formEmail, token)
             ])
           )
           .then(() => res.send(exists))

--- a/react-backend/routes/cbauthentication/cb_register.js
+++ b/react-backend/routes/cbauthentication/cb_register.js
@@ -5,12 +5,14 @@ const sendCBemail = require('../../functions/sendCBemail');
 
 router.post('/', (req, res, next) => {
   const { formPswd, formName, formEmail, formGenre } = req.body;
+  const pmClient = req.app.get('client:postmark');
+  const secret = req.app.get('cfg').session.hmac_secret;
 
-  const hashedPassword = hashCB(formPswd);
+  const hashedPassword = hashCB(secret, formPswd);
   const name = formName.toLowerCase();
 
   cbAdd(name, formEmail, formGenre, hashedPassword)
-    .then(() => sendCBemail(formEmail, formName))
+    .then(() => sendCBemail(pmClient, formEmail, formName))
     .then(() => res.send({ success: true }))
     .catch(next);
 });

--- a/react-backend/routes/cbauthentication/mw_admin_is_authenticated.js
+++ b/react-backend/routes/cbauthentication/mw_admin_is_authenticated.js
@@ -2,9 +2,11 @@ const jwt = require('jsonwebtoken');
 const getCBFromEmail = require('../../database/queries/cb/cb_from_email');
 
 const adminIsAuthenticated = (req, res, next) => {
+  const secret = req.app.get('cfg').session.jwt_secret;
+
   jwt.verify(
     req.headers.authorization,
-    process.env.ADMIN_SECRET,
+    secret,
     (err, payload) => {
       if (err) {
         return res.status(401).send({ error: 'Token expired' });
@@ -13,7 +15,7 @@ const adminIsAuthenticated = (req, res, next) => {
         .then(cb => {
           const token = jwt.sign(
             { email: payload.email, admin: true },
-            process.env.ADMIN_SECRET,
+            secret,
             { expiresIn: '5m' }
           );
 

--- a/react-backend/routes/cbauthentication/mw_is_authenticated.js
+++ b/react-backend/routes/cbauthentication/mw_is_authenticated.js
@@ -2,7 +2,8 @@ const jwt = require('jsonwebtoken');
 const cbFromEmail = require('../../database/queries/cb/cb_from_email');
 
 const isAuthenticated = (req, res, next) => {
-  jwt.verify(req.headers.authorization, process.env.SECRET, (err, payload) => {
+  const secret = req.app.get('cfg').session.jwt_secret;
+  jwt.verify(req.headers.authorization, secret, (err, payload) => {
     if (err) {
       console.log(err);
       return next('notauthorized');

--- a/react-backend/routes/qr_generator.js
+++ b/react-backend/routes/qr_generator.js
@@ -5,13 +5,15 @@ const hash = require('../functions/hash');
 const sendQrCode = require('../functions/qr_send');
 
 router.post('/', (req, res, next) => {
+  const pmClient = req.app.get('client:postmark');
+  const secret = req.app.get('cfg').session.hmac_secret;
   const { formSender, formSex, formYear, formEmail } = req.body;
-  const hashString = hash(req.body);
+  const hashString = hash(secret, req.body);
   const name = formSender.toLowerCase();
 
   userRegister(req.auth.cb_id, name, formSex, formYear, formEmail, hashString)
     .then(() => {
-      sendQrCode(formEmail, formSender, hashString, req.auth.cb_logo);
+      sendQrCode(pmClient, formEmail, formSender, hashString, req.auth.cb_logo);
       return hashString;
     })
     .then(qrcodemaker)

--- a/react-backend/routes/qr_user_send.js
+++ b/react-backend/routes/qr_user_send.js
@@ -4,9 +4,11 @@ const generatePdf = require('../functions/pdfgenerator');
 const sendEmail = require('../functions/sendemail');
 
 router.post('/', (req, res, next) => {
+  const pmClient = req.app.get('client:postmark');
+
   qrCodeMaker(req.body.hash)
     .then(QRcodeBase64Url => generatePdf(QRcodeBase64Url, req.auth.cb_logo))
-    .then(pdf => sendEmail(req.body.email, req.body.name, pdf))
+    .then(pdf => sendEmail(pmClient, req.body.email, req.body.name, pdf))
     .then(() => res.send({ success: true }))
     .catch(next);
 });

--- a/react-backend/shared/middleware.js
+++ b/react-backend/shared/middleware.js
@@ -1,0 +1,26 @@
+/*
+ * Common middleware
+ *
+ * To be mounted on the root app
+ */
+
+// catch 404 and forward to error handler
+exports.notFound = (req, res, next) => {
+  const err = new Error('Not Found');
+  err.status = 404;
+  next(err);
+};
+
+// error handler
+exports.errorHandler = (err, req, res) => {
+  if (err === 'notauthorized') {
+    return res.status(401).send({ error: 'Not logged in' });
+  }
+  // set locals, only providing error in development
+  const message = err.message;
+  const error = req.app.get('env') === 'development' ? err : {};
+
+  // render the error page
+  res.status(err.status || 500);
+  res.send({ error, message });
+};

--- a/tests/config/index.test.js
+++ b/tests/config/index.test.js
@@ -62,6 +62,8 @@ test('Config | readConfig | dev | without SSL', (t) => {
   const config = readConfig('dev');
 
   t.deepEqual(config.psql.ssl, false, 'SSL connection should be disabled');
+
+  process.env.DATABASE_URL_DEV = temp;
   t.end();
 });
 
@@ -72,6 +74,8 @@ test('Config | readConfig | dev | with SSL', (t) => {
   const config = readConfig('dev');
 
   t.deepEqual(config.psql.ssl, true, 'SSL connection should be enabled');
+
+  process.env.DATABASE_URL_DEV = temp;
   t.end();
 });
 

--- a/tests/config/index.test.js
+++ b/tests/config/index.test.js
@@ -1,0 +1,134 @@
+const test = require('tape');
+const fs = require('fs');
+const path = require('path');
+const { readConfig, validateConfig } = require('../../config');
+
+
+test('Config | readConfig | dev | undefined path', (t) => {
+  const config = readConfig('dev');
+
+  t.deepEqual(
+    config.web,
+    { port: 3000, host: 'localhost', tls: null },
+    'Web config should be configured for the dev environment'
+  );
+  t.end();
+});
+
+test('Config | readConfig | test | undefined path', (t) => {
+  const config = readConfig('test');
+
+  t.deepEqual(
+    config.web,
+    { port: 3001, host: 'localhost', tls: null },
+    'Web config should be configured for the test environment'
+  );
+  t.end();
+});
+
+test('Config | readConfig | prod | undefined path', (t) => {
+  const config = readConfig('prod');
+
+  t.deepEqual(
+    config.web,
+    { port: 3002, host: 'localhost', tls: null },
+    'Web config should be configured for the prod environment'
+  );
+  t.end();
+});
+
+test('Config | readConfig | dev | defined path', (t) => {
+  const fpath = path.join(__dirname, 'foo.json');
+
+  fs.writeFileSync(fpath, JSON.stringify({ web: { port: 1000 } }));
+
+  const config = readConfig('dev', fpath);
+
+  t.deepEqual(
+    config.web,
+    { port: 1000, host: 'localhost', tls: null },
+    'Web config should be overridden by the given file'
+  );
+
+  fs.unlinkSync(fpath);
+
+  t.end();
+});
+
+test('Config | readConfig | dev | without SSL', (t) => {
+  const temp = process.env.DATABASE_URL_DEV;
+  process.env.DATABASE_URL_DEV = temp.replace('ssl=true', '');
+
+  const config = readConfig('dev');
+
+  t.deepEqual(config.psql.ssl, false, 'SSL connection should be disabled');
+  t.end();
+});
+
+test('Config | readConfig | dev | with SSL', (t) => {
+  const temp = process.env.DATABASE_URL_DEV;
+  process.env.DATABASE_URL_DEV = `${temp.replace(/\?.*/, '')}?ssl=true`;
+
+  const config = readConfig('dev');
+
+  t.deepEqual(config.psql.ssl, true, 'SSL connection should be enabled');
+  t.end();
+});
+
+test('Config | validateConfig | valid config', (t) => {
+  const cfg = {
+    env: 'dev',
+    web: {
+      host: 'localhost',
+      port: 1000,
+      tls: null
+    },
+    psql: {
+      host: 'localhost',
+      port: 5432,
+      database: 'postgres',
+      user: 'foo'
+    },
+    email: {
+      postmark_key: 'hello',
+      twine_email: 'visitor@twineplatform.org'
+    },
+    session: {
+      jwt_secret: 'secretstring20202020',
+      hmac_secret: 'secretstringagain202020',
+      ttl: 108000000
+    }
+  };
+
+  t.doesNotThrow(() => validateConfig(cfg));
+  t.end();
+});
+
+test('Config | validateConfig | invalid config', (t) => {
+  const cfg = {
+    env: 'dev',
+    web: {
+      host: 'localhost',
+      port: 1000,
+      tls: null
+    },
+    psql: {
+      host: 'localhost',
+      port: 5432,
+      database: 'postgres',
+      user: 'foo'
+    },
+    email: {
+      postmark_key: null,
+      twine_email: null
+    },
+    session: {
+      jwt_secret: null,
+      hmac_secret: null,
+      ttl: 108000000
+    }
+  };
+
+  t.throws(() => validateConfig(cfg));
+  t.end();
+});

--- a/tests/routes_tests/cbauthentication_tests/cb_login.test.js
+++ b/tests/routes_tests/cbauthentication_tests/cb_login.test.js
@@ -1,9 +1,14 @@
 const test = require('tape');
 const request = require('supertest');
-const app = require('../../../react-backend/app');
+const createApp = require('../../../react-backend/app');
+const { getConfig } = require('../../../config');
+
+const config = getConfig(process.env.NODE_ENV);
 
 test('POST /api/cb/login | authentication successful', (t) => {
   const successPayload = { formEmail: 'findmyfroggy@frogfinders.com', formPswd: 'Funnyfingers11!' };
+  const app = createApp(config);
+
   request(app)
     .post('/api/cb/login')
     .send(successPayload)
@@ -14,10 +19,13 @@ test('POST /api/cb/login | authentication successful', (t) => {
       t.end();
     });
 });
+
 test('POST /api/cb/login | authentication unsuccessful', (t) => {
   t.plan(4);
   const failPayload = { formEmail: 'findmyfroggy@frogfinders.com', formPswd: 'password123' };
   const emptyPayload = { formEmail: '', formPswd: '' };
+  const app = createApp(config);
+
   request(app)
     .post('/api/cb/login')
     .send(failPayload)
@@ -27,6 +35,7 @@ test('POST /api/cb/login | authentication unsuccessful', (t) => {
       t.notOk(err, err || 'Passes supertest expect criteria');
       t.notOk(res.body.success, 'cb failed to log in with incorrect password');
     });
+
   request(app)
     .post('/api/cb/login')
     .send(emptyPayload)

--- a/tests/routes_tests/cbauthentication_tests/cb_password_change.test.js
+++ b/tests/routes_tests/cbauthentication_tests/cb_password_change.test.js
@@ -1,14 +1,18 @@
 const test = require('tape');
 const request = require('supertest');
-const app = require('../../../react-backend/app');
+const createApp = require('../../../react-backend/app');
 const tokenGen = require('../../../react-backend/functions/tokengen');
 const dbConnection = require('../../../react-backend/database/dbConnection');
 const rebuild = require('../../../react-backend/database/database_rebuild');
+const { getConfig } = require('../../../config');
+
+const config = getConfig(process.env.NODE_ENV);
 
 test('POST /api/cb/pwd/change | token check/pw update successful', async (t) => {
   await rebuild();
   const token = await tokenGen();
   const tokenExpire = Date.now() + 36000;
+  const app = createApp(config);
 
   try {
     const queryText = 'UPDATE cbusiness SET token = $1, tokenexpire = $2 WHERE id = 3';
@@ -44,6 +48,7 @@ test('POST /api/cb/pwd/change | token check/pw update successful', async (t) => 
 });
 
 test('POST /api/cb/pwd/change | token check/pw update unsuccessful', (t) => {
+  const app = createApp(config);
   const failPayload = {
     formPswd: 'lol',
     formPswdConfirm: 'lol',

--- a/tests/routes_tests/cbauthentication_tests/cb_password_reset.test.js
+++ b/tests/routes_tests/cbauthentication_tests/cb_password_reset.test.js
@@ -1,11 +1,16 @@
 const test = require('tape');
 const request = require('supertest');
-const app = require('../../../react-backend/app');
+const createApp = require('../../../react-backend/app');
 const dbConnection = require('../../../react-backend/database/dbConnection');
 const rebuild = require('../../../react-backend/database/database_rebuild');
+const { getConfig } = require('../../../config');
+
+const config = getConfig(process.env.NODE_ENV);
+
 
 test('POST api/cb/pwd/reset | token creation successful', async (t) => {
   await rebuild();
+  const app = createApp(config);
 
   const successPayload = { formEmail: 'findmyfroggy@frogfinders.com' };
   request(app)
@@ -29,7 +34,9 @@ test('POST api/cb/pwd/reset | token creation successful', async (t) => {
 test('POST api/cb/pwd/reset | token creation unsuccessful', async (t) => {
   await rebuild();
 
+  const app = createApp(config);
   const unsuccessPayload = { formEmail: 'idont@exist.com' };
+
   request(app)
     .post('/api/cb/pwd/reset')
     .send(unsuccessPayload)


### PR DESCRIPTION
Fixes #190 
Fixes #220

So here it is!

### Main changes
* We now have a single configuration object that should be referred to by all code
* `app.js` now exports a function that creates an express app given a configuration object
* This means tests relying on the `app` now need to create it themselves with the appropriate configuration. I've done this for the tests that are already on master.
* This is actually only a partial update because currently `dbConnection.js` and all files relying on it are unchanged. I decided to leave this because it would inflate the diff unnecessarily. I will finish off this work in a subsequent PR. After that's done we should be able to remove the `process.exit` nonsense from the tests 🎉 

### Minor changes
* `ramda` and `joi` added as dependencies
* Removed one of the nested `eslintrc` files