### PR TITLE
Update cb admin API + form validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -577,11 +577,18 @@
       }
     },
     "boom": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-7.2.0.tgz",
+      "integrity": "sha1-K/8kpVVldn/ehp7ICDF+sQxI6WY=",
       "requires": {
-        "hoek": "2.16.3"
+        "hoek": "5.0.3"
+      },
+      "dependencies": {
+        "hoek": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-5.0.3.tgz",
+          "integrity": "sha512-Bmr56pxML1c9kU+NS51SMFkiVQAb+9uFfXwyqR2tn4w2FPvmPt65eZ9aCcEfRXd9G74HkZnILC6p967pED4aiw=="
+        }
       }
     },
     "boxen": {
@@ -1218,6 +1225,16 @@
       "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
       "requires": {
         "boom": "2.10.1"
+      },
+      "dependencies": {
+        "boom": {
+          "version": "2.10.1",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+          "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        }
       }
     },
     "crypto": {
@@ -3386,6 +3403,16 @@
         "cryptiles": "2.0.5",
         "hoek": "2.16.3",
         "sntp": "1.0.9"
+      },
+      "dependencies": {
+        "boom": {
+          "version": "2.10.1",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+          "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        }
       }
     },
     "hoek": {

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
   "dependencies": {
     "babel-eslint": "^8.2.2",
     "body-parser": "^1.17.2",
+    "boom": "^7.2.0",
     "cookie-parser": "~1.4.3",
     "crypto": "^1.0.1",
     "debug": "~2.6.3",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "heroku-postbuild":
       "cd react-backend/client && npm install --only=dev && npm install && npm run build",
     "build.client": "cd react-backend/client && npm run build",
-    "test": "NODE_ENV=test tape '**/__tests__/*.test.js' | tap-spec",
+    "test": "NODE_ENV=test tape 'react-backend/!(client)/**/__tests__/*.test.js' | tap-spec",
     "start.client": "cd react-backend/client && npm run start",
     "cover": "nyc npm test",
     "cover.report": "nyc report --reporter=html",

--- a/react-backend/client/src/App.js
+++ b/react-backend/client/src/App.js
@@ -66,12 +66,12 @@ class App extends Component {
             component={HomePage}
           />
 
-          <Route exact path="/signupcb" component={CbSignupPage} />
-          <Route exact path="/newPassword/:token" component={ResetPassword} />
-          <Route exact path="/pswdresetcb" component={ForgotPassword} />
+          <Route exact path="/cb/register" component={CbSignupPage} />
+          <Route exact path="/cb/password/reset/:token" component={ResetPassword} />
+          <Route exact path="/cb/password/forgot" component={ForgotPassword} />
           <Route
             exact
-            path="/logincb"
+            path="/cb/login"
             render={props =>
               (this.state.loggedIn ? (
                 <Redirect to="/" />

--- a/react-backend/client/src/PrivateRoute.js
+++ b/react-backend/client/src/PrivateRoute.js
@@ -11,7 +11,7 @@ const ProtectedRoute = ({ auth, component: Component, ...rest }) => (
           ? <Component {...props} {...rest} />
           : <Redirect
             to={{
-              pathname: '/logincb',
+              pathname: '/cb/login',
               state: { from: props.location }, // eslint-disable-line react/prop-types
             }}
           />

--- a/react-backend/client/src/api/index.js
+++ b/react-backend/client/src/api/index.js
@@ -2,6 +2,7 @@
  *
  */
 import axios from 'axios';
+import { head, pathOr, equals } from 'ramda';
 
 
 export const Activities = {
@@ -212,8 +213,8 @@ export const CbAdmin = {
     axios.post(
       '/api/cb/pwd/change',
       {
-        formPswd: password,
-        formPswdConfirm: passwordConfirm,
+        password,
+        passwordConfirm,
         token: tkn,
       },
     ),
@@ -222,8 +223,8 @@ export const CbAdmin = {
     axios.post(
       '/api/cb/login',
       {
-        formEmail: email,
-        formPswd: password,
+        email,
+        password,
       },
     ),
 
@@ -240,7 +241,7 @@ export const CbAdmin = {
     axios.post(
       '/api/cb/pwd/reset',
       {
-        formEmail: email,
+        email,
       },
     ),
 
@@ -256,8 +257,16 @@ export const CbAdmin = {
 };
 
 
+export const ErrorUtils = {
+  getErrorStatus: pathOr(null, ['response', 'status']),
+  getValidationErrors: head(pathOr('Unknown error', ['response', 'data', 'validation'])),
+  errorStatusEquals: (error, status) => equals(ErrorUtils.getErrorStatus(error), status),
+};
+
+
 export default {
   Activities,
   Visitors,
   CbAdmin,
+  ErrorUtils,
 };

--- a/react-backend/client/src/cb-admin/pages/ConfirmPassword.js
+++ b/react-backend/client/src/cb-admin/pages/ConfirmPassword.js
@@ -64,7 +64,7 @@ export default class ConfirmPassword extends React.Component {
             />
             <SubmitButton>CONTINUE</SubmitButton>
             <div style={{ textAlign: 'center', margin: '2em 0', width: '90%' }}>
-              <Link to="/pswdresetcb">Forgot password?</Link>
+              <Link to="/cb/password/forgot">Forgot password?</Link>
             </div>
           </FormSection>
         </Form>

--- a/react-backend/client/src/cb-admin/pages/ForgotPassword.js
+++ b/react-backend/client/src/cb-admin/pages/ForgotPassword.js
@@ -80,7 +80,7 @@ export default class ForgotPassword extends React.Component {
             />
             <SubmitButton>CONTINUE</SubmitButton>
             <div style={{ textAlign: 'center', margin: '2em 0', width: '90%' }}>
-              <Link to="/logincb">Back to login</Link>
+              <Link to="/cb/login">Back to login</Link>
             </div>
           </FormSection>
         </Form>

--- a/react-backend/client/src/cb-admin/pages/Login.js
+++ b/react-backend/client/src/cb-admin/pages/Login.js
@@ -88,10 +88,10 @@ export default class Login extends React.Component {
           </FormSection>
         </Form>
         <CenteredParagraph>
-          Not a subscriber? <Link to="/signupcb">Create a new account</Link>
+          Not a subscriber? <Link to="/cb/register">Create a new account</Link>
         </CenteredParagraph>
         <CenteredParagraph>
-          <LightLink to="/pswdresetcb">Forgot your password?</LightLink>
+          <LightLink to="/cb/password/forgot">Forgot your password?</LightLink>
         </CenteredParagraph>
       </FlexContainerCol>
     );

--- a/react-backend/client/src/cb-admin/pages/Login.js
+++ b/react-backend/client/src/cb-admin/pages/Login.js
@@ -1,8 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { CbAdmin } from '../../api';
-import errorMessages from '../../components/errors';
+import { CbAdmin, ErrorUtils } from '../../api';
 import { FlexContainerCol } from '../../shared/components/layout/base';
 import { Heading, Paragraph, Link } from '../../shared/components/text/base';
 import { Form, FormSection, PrimaryButton } from '../../shared/components/form/base';
@@ -40,22 +39,28 @@ export default class Login extends React.Component {
     e.preventDefault();
 
     CbAdmin.login({ email: this.state.email, password: this.state.password })
-      .then(res => res.data)
-      .then((data) => {
-        if (data.success === true) {
-          localStorage.setItem('token', data.token);
-          this.props.setLoggedIn();
-          this.props.history.push('/');
-        } else if (data.reason === 'email') {
-          this.setError([errorMessages.EMAIL_ERROR]);
-        } else if (data.reason === 'noinput') {
-          this.setError([errorMessages.NO_INPUT_ERROR]);
-        } else {
-          this.setError([errorMessages.DETAILS_ERROR]);
-        }
+      .then((res) => {
+        localStorage.setItem('token', res.data.token);
+        this.props.setLoggedIn();
+        this.props.history.push('/');
       })
-      .catch(() => {
-        this.props.history.push('/internalServerError');
+      .catch((error) => {
+        if (ErrorUtils.errorStatusEquals(error, 400)) {
+          this.setState({ errors: ErrorUtils.getValidationErrors(error) });
+
+        } else if (ErrorUtils.errorStatusEquals(error, 401)) {
+          this.setState({ errors: { email: error.response.data.error } });
+
+        } else if (ErrorUtils.errorStatusEquals(error, 500)) {
+          this.props.history.push('/error/500');
+
+        } else if (ErrorUtils.errorStatusEquals(error, 404)) {
+          this.props.history.push('/error/404');
+
+        } else {
+          this.props.history.push('/error/unknown');
+
+        }
       });
   }
 
@@ -73,7 +78,7 @@ export default class Login extends React.Component {
               label="Email"
               name="email"
               type="email"
-              errors={errors.email}
+              error={errors.email}
               requried
             />
             <LabelledInput
@@ -81,7 +86,7 @@ export default class Login extends React.Component {
               label="Password"
               name="password"
               type="password"
-              errors={errors.password}
+              error={errors.password}
               requried
             />
             <SubmitButton>LOGIN</SubmitButton>

--- a/react-backend/client/src/cb-admin/pages/ResetPassword.js
+++ b/react-backend/client/src/cb-admin/pages/ResetPassword.js
@@ -42,6 +42,9 @@ export default class ResetPassword extends React.Component {
         if (errorStatusEquals(error, 400)) {
           this.setState({ errors: getValidationErrors(error) });
 
+        } else if (errorStatusEquals(error, 401)) {
+          this.setState({ errors: { password: error.response.data.error } });
+
         } else if (errorStatusEquals(error, 500)) {
           this.history.push('/error/500');
 
@@ -68,7 +71,7 @@ export default class ResetPassword extends React.Component {
               label="New password"
               type="password"
               name="password"
-              errror={errors.password}
+              error={errors.password}
               required
             />
             <LabelledInput
@@ -76,7 +79,7 @@ export default class ResetPassword extends React.Component {
               label="Confirm new password"
               type="password"
               name="passwordConfirm"
-              errror={errors.passwordConfirm}
+              error={errors.passwordConfirm}
               required
             />
             <SubmitButton type="submit">Submit</SubmitButton>

--- a/react-backend/client/src/cb-admin/pages/Signup.js
+++ b/react-backend/client/src/cb-admin/pages/Signup.js
@@ -164,7 +164,7 @@ export default class CbAdminSignup extends React.Component {
 
           <FormSection flexOrder={4}>
             <Paragraph>
-              Already a subscriber? <Link to="/logincb">Login</Link>
+              Already a subscriber? <Link to="/cb/login">Login</Link>
             </Paragraph>
           </FormSection>
         </Form>

--- a/react-backend/client/src/cb-admin/pages/Signup.js
+++ b/react-backend/client/src/cb-admin/pages/Signup.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { pick, pathOr, equals } from 'ramda';
-import { CbAdmin } from '../../api';
+import { pick } from 'ramda';
+import { CbAdmin, ErrorUtils } from '../../api';
 import { Form, FormSection, PrimaryButton } from '../../shared/components/form/base';
 import { Heading, Paragraph, Link } from '../../shared/components/text/base';
 import LabelledInput from '../../shared/components/form/LabelledInput';
@@ -44,10 +44,6 @@ const payloadFromState = pick([
   'password_confirm',
 ]);
 
-const getErrorStatus = pathOr(null, ['response', 'status']);
-const getValidationErrors = pathOr('Unknown error', ['response', 'data', 'validation']);
-const errorStatusEquals = (error, status) => equals(getErrorStatus(error), status);
-
 const SubmitButton = styled(PrimaryButton)`
   height: 4em;
   width: 90%;
@@ -79,18 +75,17 @@ export default class CbAdminSignup extends React.Component {
         this.props.history.push('/cb/login?ref=signup');
       })
       .catch((error) => {
-        console.log(error.response);
-        if (errorStatusEquals(error, 400)) {
-          this.setState({ errors: getValidationErrors(error) });
+        if (ErrorUtils.errorStatusEquals(error, 400)) {
+          this.setState({ errors: ErrorUtils.getValidationErrors(error) });
 
-        } else if (errorStatusEquals(error, 500)) {
-          this.history.push('/error/500');
+        } else if (ErrorUtils.errorStatusEquals(error, 500)) {
+          this.props.history.push('/error/500');
 
-        } else if (errorStatusEquals(error, 404)) {
-          this.history.push('/error/404');
+        } else if (ErrorUtils.errorStatusEquals(error, 404)) {
+          this.props.history.push('/error/404');
 
         } else {
-          this.history.push('/error/unknown');
+          this.props.history.push('/error/unknown');
 
         }
       });

--- a/react-backend/client/src/components/visitors/logoutbutton.js
+++ b/react-backend/client/src/components/visitors/logoutbutton.js
@@ -11,7 +11,7 @@ export default class Logoutbutton extends Component {
     localStorage.removeItem('token');
     localStorage.removeItem('adminToken');
     this.props.updateLoggedIn();
-    this.props.redirectUser('/logincb');
+    this.props.redirectUser('/cb/login');
   };
 
   render() {

--- a/react-backend/client/src/shared/pages/Home.js
+++ b/react-backend/client/src/shared/pages/Home.js
@@ -45,7 +45,7 @@ export default props => (
   <FlexContainerCol justify="space-around">
     <StyledNav>
       <FlexItem>
-        <HyperLink to="/logincb" onClick={logout(props)}> Logout </HyperLink>
+        <HyperLink to="/cb/login" onClick={logout(props)}> Logout </HyperLink>
       </FlexItem>
       <FlexItem flex="2">
         <Heading> Who are you? </Heading>

--- a/react-backend/routes/__tests__/admin_login.test.js
+++ b/react-backend/routes/__tests__/admin_login.test.js
@@ -16,6 +16,7 @@ test('POST /api/admin/login | password match database hash', t => {
   const successPayload = {
     password: 'Sallydog7&',
   };
+
   request(app)
     .post('/api/admin/login')
     .set('authorization', token)
@@ -24,7 +25,12 @@ test('POST /api/admin/login | password match database hash', t => {
     .expect('Content-Type', /json/)
     .end((err, res) => {
       t.notOk(err, err || 'Passes supertest expect criteria');
-      t.equal(res.body.success, true);
+
+      const tokenPayload = jwt.decode(res.body.result.token);
+
+      t.deepEqual(tokenPayload.email, 'jinglis12@googlemail.com');
+      t.equal(tokenPayload.admin, true);
+
       dbConnection.end(t.end);
     });
 });
@@ -43,11 +49,11 @@ test('POST /api/admin/login | no password match for database hash', t => {
     .post('/api/admin/login')
     .set('authorization', token)
     .send(failurePayload)
-    .expect(200)
+    .expect(401)
     .expect('Content-Type', /json/)
     .end((err, res) => {
       t.notOk(err, err || 'Passes supertest expect criteria');
-      t.notEqual(res.body.success, true);
+      t.deepEqual(res.body, { result: null, error: 'Incorrect password' });
       dbConnection.end(t.end);
     });
 });

--- a/react-backend/routes/admin_login.js
+++ b/react-backend/routes/admin_login.js
@@ -1,31 +1,46 @@
 const express = require('express');
+const Joi = require('joi');
+const Boom = require('boom');
 const jwt = require('jsonwebtoken');
 const hashCB = require('../functions/cbhash');
 const cbLogin = require('../database/queries/cb/cb_login');
+const { validate } = require('../shared/middleware');
+
 
 const router = express.Router();
+const schemas = {
+  body: {
+    password: Joi.string().min(1).required(),
+  },
+};
 
-router.post('/', (req, res, next) => {
+
+router.post('/', validate(schemas), async (req, res, next) => {
   const { password } = req.body;
   const pgClient = req.app.get('client:psql');
   const secret = req.app.get('cfg').session.hmac_secret;
   const cbAdminJwtSecret = req.app.get('cfg').session.cb_admin_jwt_secret;
   const hashedPassword = hashCB(secret, password);
 
-  cbLogin(pgClient, req.auth.cb_email, hashedPassword)
-    .then(exists => {
-      if (exists) {
-        const token = jwt.sign(
-          { email: req.auth.cb_email, admin: true },
-          cbAdminJwtSecret,
-          { expiresIn: '5m' }
-        );
+  try {
+    const exists = await cbLogin(pgClient, req.auth.cb_email, hashedPassword);
 
-        return res.send({ success: true, token });
-      }
-      res.send({ success: false, reason: 'Incorrect password' });
-    })
-    .catch(next);
+    if (! exists) {
+      return next(Boom.unauthorized('Incorrect password'));
+    }
+
+    const token = jwt.sign(
+      { email: req.auth.cb_email, admin: true },
+      cbAdminJwtSecret,
+      { expiresIn: '5m' }
+    );
+
+    return res.send({ result: { token } });
+
+  } catch (error) {
+    return next(error);
+
+  }
 });
 
 module.exports = router;

--- a/react-backend/routes/cbauthentication/__tests__/cb_password_change.test.js
+++ b/react-backend/routes/cbauthentication/__tests__/cb_password_change.test.js
@@ -18,53 +18,87 @@ test('POST /api/cb/pwd/change | token check/pw update successful', async (t) => 
     const queryText = 'UPDATE cbusiness SET token = $1, tokenexpire = $2 WHERE id = 3';
     await dbConnection.query(queryText, [token, tokenExpire]);
   } catch (error) {
-    t.end(error);
+    return t.end(error);
   }
 
-  const successPayload = {
-    formPswd: 'Funnyfingers22!',
-    formPswdConfirm: 'Funnyfingers22!',
+  const payload = {
+    password: 'Funnyfingers22!',
+    passwordConfirm: 'Funnyfingers22!',
     token,
   };
 
   request(app)
     .post('/api/cb/pwd/change')
-    .send(successPayload)
+    .send(payload)
     .expect(200)
     .expect('Content-Type', /json/)
     .end(async (err, res) => {
       t.notOk(err, err || 'Passes supertest expect criteria');
-      t.ok(res.body === true, 'matching passwords entered/token check on db returns true');
+      t.deepEqual(res.body, { result: null }, 'matching passwords entered/token check on db');
       const oldPassword = '0a0429fa911712f7aca189bb12995963e3fc8f361e2845f747994be499250762';
 
       try {
         const newPassword = await dbConnection.query('SELECT hash_pwd FROM cbusiness WHERE id = 3');
         t.notEqual(newPassword, oldPassword, 'Password has been changed in db');
-        await dbConnection.end();
         t.end();
+
       } catch (error) {
-        await dbConnection.end();
         t.end(error);
+
+      } finally {
+        dbConnection.end();
+
       }
     });
 });
 
-test('POST /api/cb/pwd/change | token check/pw update unsuccessful', (t) => {
+test('POST /api/cb/pwd/change | invalid token', (t) => {
   const app = createApp(config);
   const dbConnection = app.get('client:psql');
   const failPayload = {
-    formPswd: 'lol',
-    formPswdConfirm: 'lol',
+    password: 'CrappyPassword7*',
+    passwordConfirm: 'CrappyPassword7*',
     token: 'lol',
   };
   request(app)
     .post('/api/cb/pwd/change')
     .send(failPayload)
-    .expect(400)
-    .expect('Content-Type', /text/)
+    .expect(401)
+    .expect('Content-Type', /json/)
     .end((err, res) => {
       t.notOk(err, err || 'Passes supertest expect criteria');
-      t.equal(res.text, 'tokenmatch', 'cb failed to log in with incorrect password');
+      t.deepEqual(res.body, { result: null, error: 'Token not recognised' }, 'failed to log in with invalid token');
+      dbConnection.end(t.end);
+    });
+});
+
+test('POST /api/cb/pwd/change | expired token', async (t) => {
+  const token = await tokenGen();
+  const tokenExpire = Date.now();
+  const app = createApp(config);
+  const dbConnection = app.get('client:psql');
+
+  try {
+    const queryText = 'UPDATE cbusiness SET token = $1, tokenexpire = $2 WHERE id = 3';
+    await dbConnection.query(queryText, [token, tokenExpire]);
+  } catch (error) {
+    return t.end(error);
+  }
+
+  const payload = {
+    password: 'Funnyfingers22!',
+    passwordConfirm: 'Funnyfingers22!',
+    token,
+  };
+
+  request(app)
+    .post('/api/cb/pwd/change')
+    .send(payload)
+    .expect(401)
+    .expect('Content-Type', /json/)
+    .end(async (err, res) => {
+      t.notOk(err, err || 'Passes supertest expect criteria');
+      t.deepEqual(res.body, { result: null, error: 'Token expired' }, 'failed to log in with expired token');
       dbConnection.end(t.end);
     });
 });

--- a/react-backend/routes/cbauthentication/__tests__/cb_register.test.js
+++ b/react-backend/routes/cbauthentication/__tests__/cb_register.test.js
@@ -19,14 +19,15 @@ test('POST /api/cb/register | viable & registered CB', async t => {
     password: 'Chickens5*',
     passwordConfirm: 'Chickens5*',
   };
+
   request(app)
     .post('/api/cb/register')
     .send(successPayload)
-    .expect(200)
+    .expect(409)
     .expect('Content-Type', /json/)
     .end((err, res) => {
       t.notOk(err, err || 'Passes supertest expect criteria');
-      t.equal(res.text, 'true');
+      t.deepEqual(res.body, { result: null, error: 'Business already registered' });
       dbConnection.end(t.end);
     });
 });
@@ -51,7 +52,7 @@ test('POST /api/cb/register | viable & non-registered CB', async t => {
       .expect('Content-Type', /json/)
       .end((err, res) => {
         t.notOk(err, err || 'Passes supertest expect criteria');
-        t.deepEqual(res.body, { success: true });
+        t.deepEqual(res.body, { result: null });
         dbConnection.end(t.end);
       });
   });

--- a/react-backend/shared/middleware/error.js
+++ b/react-backend/shared/middleware/error.js
@@ -3,6 +3,8 @@
  *
  * To be mounted on the root app
  */
+const Boom = require('boom');
+
 
 // catch 404 and forward to error handler
 exports.notFound = (req, res, next) => {
@@ -12,7 +14,13 @@ exports.notFound = (req, res, next) => {
 };
 
 // error handler
-exports.errorHandler = (err, req, res) => {
+exports.errorHandler = (err, req, res, next) => { // eslint-disable-line
+  if (Boom.isBoom(err)) {
+    const { statusCode, message } = err.output.payload;
+
+    return res.status(statusCode).send({ result: null, error: message });
+  }
+
   if (err === 'notauthorized') {
     return res.status(401).send({ error: 'Not logged in' });
   }
@@ -21,6 +29,5 @@ exports.errorHandler = (err, req, res) => {
   const error = req.app.get('env') === 'development' ? err : {};
 
   // render the error page
-  res.status(err.status || 500);
-  res.send({ error, message });
+  res.status(err.status || 500).send({ error, message });
 };


### PR DESCRIPTION
Completes the functionality left half finished in #301 

* Use more sensible URL structure for cb side of client app
* Move CB authentication routes closer to the desired standard outlined by API docs
  * Add `Joi` validation
  * Standardise responses and request fields
  * Add `Boom` to standardise error handling