### PR TITLE
🚀 read port from environment

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -59,7 +59,7 @@ const nodeEnvs = {
   prod: (cfg) =>
     mergeDeepRight(cfg, {
       env: 'prod',
-      web: { port: 4002 },
+      web: { port: process.env.PORT || 4002 },
       psql: parseDbUrl(process.env.DATABASE_URL || process.env.DATABASE_URL_PROD),
       email: { postmark_key: process.env.POSTMARK_KEY_PROD },
     }),


### PR DESCRIPTION
Heroku requires apps to bind to the port set in the `$PORT` environment variable, but we only need to do this for the production environment.