### PR TITLE
🐛 display error message on incorrect pwd

### DIFF
--- a/client/src/cb-admin/pages/ConfirmPassword.js
+++ b/client/src/cb-admin/pages/ConfirmPassword.js
@@ -39,8 +39,8 @@ export default class ConfirmPassword extends React.Component {
         this.props.updateAdminToken(data.result.token);
         this.props.history.push('/admin');
       })
-      .catch((error) => {
-        console.log(error);
+      .catch(() => {
+        this.setState({ errors: { password: 'Wrong password' } });
       });
   };
 


### PR DESCRIPTION
Fixes #373

#### Changes
* Set error message on failed password confirmation

##### Fixing Bugs
* [ ] ~~Have I added a (set of) test(s) that proves the bug is fixed?~~
* [ ] ~~Have I documented any necessary developer notes/gotchas/lessons learnt from this bug fix?~~

Was just laziness/oversight not adding error handling