### PR TITLE
🚑 fix instascan critical error

### DIFF
--- a/docs/dev_notes.md
+++ b/docs/dev_notes.md
@@ -5,6 +5,7 @@
 1. [Database Time Zones](#database-time-zones)
 2. [Flexbox and Absolute Positioned Children](#flexbox-and-absolute-positioned-children)
 3. [PdfMake an Image Content Types](#pdfmake-and-image-content-types)
+4. [Cleaning up resources in React Components](#cleaning-up-resources-in-react-components)
 
 ## Database Time Zones
 All `date` data types in schema are set as `TIMESTAMP WITH TIME ZONE`, with entries being added as UTC in the following format `2017-05-15 12:24:56+00`. Without `TIME ZONE` added node servers will convert `date` data into js time objects in local time.
@@ -15,3 +16,9 @@ All `date` data types in schema are set as `TIMESTAMP WITH TIME ZONE`, with entr
 ## PdfMake and Image Content Types
 * Invalid PNG filters: https://github.com/bpampuch/pdfmake/issues/879
 * Correctly base-64 encoding axios responses: https://github.com/axios/axios/issues/513
+
+## Cleaning up resources in React Components
+Be careful to clean up after yourself! Temporary resources instantiated or used in a component should be deleted or cleaned up in the `componentWillUnmount` hook to prevent memory leaks and obscure errors.
+
+**Example: Instascan scanner**
+The instascan scanner activates a given camera and uses the media feed to detect QR codes. If a reference to an instance of `scanner` is left around while the camera is active, it will not be garbage collected, and continue to attempt to interact with elements that may have already been unmounted. In addition, the camera will remain active unnecessarily unless `scanner.stop` is called. This is what caused [issue #411](https://github.com/TwinePlatform/DataPower/issues/411).

--- a/server/routes/__tests__/visitor_name.test.js
+++ b/server/routes/__tests__/visitor_name.test.js
@@ -50,7 +50,7 @@ test('POST /api/user/name-from-scan | non-viable hash ', async t => {
     .expect('Content-Type', /json/)
     .end((err, res) => {
       t.notOk(err, err || 'Passes supertest expect criteria');
-      t.equal(res.body.fullname, 'Bad hash');
+      t.deepEqual(res.body, { result: null, error: 'Invalid hash' });
       dbConnection.end(t.end);
     });
 });
@@ -70,11 +70,11 @@ test('POST /api/user/name-from-scan | user/hash not registered ', async t => {
     .post('/api/user/name-from-scan')
     .set('authorization', token)
     .send(failPayload)
-    .expect(400)
+    .expect(401)
     .expect('Content-Type', /json/)
     .end((err, res) => {
       t.notOk(err, err || 'Passes supertest expect criteria');
-      t.equal(res.body.fullname, 'there is no registered user');
+      t.deepEqual(res.body, { result: null, error: "No user found" });
       dbConnection.end(t.end);
     });
 });

--- a/server/routes/visitor_name.js
+++ b/server/routes/visitor_name.js
@@ -1,5 +1,6 @@
 const router = require('express').Router();
 const validator = require('validator');
+const Boom = require('boom');
 const getHash = require('../database/queries/user_check_hash');
 
 router.post('/', (req, res, next) => {
@@ -7,16 +8,15 @@ router.post('/', (req, res, next) => {
   const pgClient = req.app.get('client:psql');
 
   if (!validator.isHash(hashToCheck, ['sha256'])) {
-    return res.status(400).send({ fullname: 'Bad hash', hash: '0' });
+    return next(Boom.badRequest('Invalid hash'));
   }
 
   getHash(pgClient, hashToCheck)
-    .then(fullname => res.send(fullname))
-    .catch(err => {
-      if (err.message !== 'No user found') return next(err);
-
-      res.status(400).send({ fullname: 'there is no registered user', hash: '0' });
-    });
+    .then(
+      fullname => res.send(fullname),
+      err => next(Boom.unauthorized(err.message))
+    )
+    .catch(next);
 });
 
 module.exports = router;


### PR DESCRIPTION
Fixes #411 

#### Changes
Instascan was repeatedly throwing errors "Uncaught abort() at Error".
Looks like this was due to not having proper clean-up code in the QRcode
component.

Added a `componentWillUnmount` hook to stop the scanner. Also moved the
scanning logic directly into `componentDidMount` instead of splitting it
between two methods, and renamed the `login` state fragment to a more
meaningful `hasScanned` boolean.

#### Checklist
##### Fixing Bugs
* [ ] ~~Have I added a (set of) test(s) that proves the bug is fixed?~~ N/A
* [x] Have I documented any necessary developer notes/gotchas/lessons learnt from this bug fix?
